### PR TITLE
feat(web): add arabic locale and rtl support

### DIFF
--- a/apps/web/i18n.json
+++ b/apps/web/i18n.json
@@ -2,7 +2,7 @@
   "version": 0,
   "locale": {
     "source": "en",
-    "targets": ["fr", "de", "es", "it", "nl"]
+    "targets": ["fr", "de", "es", "it", "nl", "ar"]
   },
   "buckets": {
     "po": {

--- a/apps/web/src/locales/ar/messages.po
+++ b/apps/web/src/locales/ar/messages.po
@@ -1,0 +1,18 @@
+msgid ""
+msgstr ""
+"Language: ar\n"
+
+msgid "Boards"
+msgstr "لوحات"
+
+msgid "Activity"
+msgstr "النشاط"
+
+msgid "Create board"
+msgstr "إنشاء لوحة"
+
+msgid "Cancel"
+msgstr "إلغاء"
+
+msgid "Welcome back"
+msgstr "مرحبًا بعودتك"

--- a/apps/web/src/locales/ar/messages.ts
+++ b/apps/web/src/locales/ar/messages.ts
@@ -1,0 +1,8 @@
+/*eslint-disable*/import type { Messages } from "@lingui/core";
+export const messages: Messages = {
+  "Boards": "لوحات",
+  "Activity": "النشاط",
+  "Create board": "إنشاء لوحة",
+  "Cancel": "إلغاء",
+  "Welcome back": "مرحبًا بعودتك",
+};

--- a/apps/web/src/locales/index.ts
+++ b/apps/web/src/locales/index.ts
@@ -1,4 +1,4 @@
-export const locales = ["en", "fr", "de", "es", "it", "nl"] as const;
+export const locales = ["en", "fr", "de", "es", "it", "nl", "ar"] as const;
 
 export type Locale = (typeof locales)[number];
 
@@ -11,4 +11,5 @@ export const localeNames: Record<Locale, string> = {
   es: "Español",
   it: "Italiano",
   nl: "Nederlands",
+  ar: "العربية",
 };

--- a/apps/web/src/providers/lingui.tsx
+++ b/apps/web/src/providers/lingui.tsx
@@ -76,6 +76,11 @@ export function LinguiProviderWrapper({
     }
   }, [locale, isHydrated]);
 
+  useEffect(() => {
+    document.documentElement.dir = locale === "ar" ? "rtl" : "ltr";
+    document.documentElement.lang = locale;
+  }, [locale]);
+
   return (
     <LinguiContext.Provider
       value={{ locale, setLocale, availableLocales: [...locales] }}

--- a/apps/web/src/utils/i18n.ts
+++ b/apps/web/src/utils/i18n.ts
@@ -18,6 +18,8 @@ const loadMessages = async (locale: Locale) => {
       return (await import("~/locales/it/messages")).messages;
     case "nl":
       return (await import("~/locales/nl/messages")).messages;
+    case "ar":
+      return (await import("~/locales/ar/messages")).messages;
     default:
       return enMessages;
   }

--- a/apps/web/src/views/card/components/ActivityList.tsx
+++ b/apps/web/src/views/card/components/ActivityList.tsx
@@ -1,7 +1,7 @@
 import { t } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
 import { formatDistanceToNow } from "date-fns";
-import { de, enGB, es, fr, it, nl } from "date-fns/locale";
+import { ar, de, enGB, es, fr, it, nl } from "date-fns/locale";
 import {
   HiOutlineArrowLeft,
   HiOutlineArrowRight,
@@ -31,6 +31,7 @@ const dateLocaleMap = {
   es: es,
   it: it,
   nl: nl,
+  ar: ar,
 } as const;
 
 const truncate = (value: string | null, maxLength = 50) => {


### PR DESCRIPTION
## Summary
- add Arabic locale and starter translations
- enable RTL direction when Arabic is active
- support Arabic date formatting

## Testing
- `pnpm --filter @kan/web lingui:compile`
- `pnpm turbo run lint --filter=@kan/web` *(fails: command exited with code 1)*
- `pnpm turbo run typecheck --filter=@kan/web` *(fails: command exited with code 2)*

------
https://chatgpt.com/codex/tasks/task_e_68bf70183a208324aeb01637438fdcb9